### PR TITLE
Add StackBlitz button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app). It is a boilerplate for [CustomHack](https://lu.ma/rnvz7h05).
 
-**tl;dr** [click here to deploy to Vercel](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flingodotdev%2Fcustom-hack-next-app)
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/lingodotdev/custom-hack-next-app)
+**tl;dr** [click here to deploy to Vercel](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flingodotdev%2Fcustom-hack-next-app) or [open in StackBlitz](https://stackblitz.com/github/lingodotdev/custom-hack-next-app).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 **tl;dr** [click here to deploy to Vercel](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flingodotdev%2Fcustom-hack-next-app)
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/lingodotdev/custom-hack-next-app)
+
 ## Getting Started
 
 First, install the dependencies via a package manager (we prefer [pnpm](https://pnpm.io/)):


### PR DESCRIPTION
Added a StackBlitz button to the README to allow users to quickly open and experiment with the project in an online IDE environment. The button is positioned right after the existing Vercel deploy button for easy access.